### PR TITLE
feat(gcp-download): setup direct download for windows updater

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ This project has been built from Sails.js up by Arek Sredzki, with inspiration f
 
 5. Added remove() method to CustomFileAdapter.js - skipper-s3 uses multiDeletes() underneath the hood; GCP does not support multi deletes. This uses the deleteObject which lets us now delete from GCP.
 
-6. Updated VersionController.js to use getSignedUrl() & pass that back to autoUpdater instead of the download url
+6. Updated VersionController.js to use getSignedUrl() & pass that back to autoUpdater instead of the download url on general updates and on Windows update
 
 7. Updated AssetController.js create function to dynamically set the dirname to current version being uploaded ex: release-v1.0.0
 

--- a/api/controllers/VersionController.js
+++ b/api/controllers/VersionController.js
@@ -317,7 +317,6 @@ module.exports = {
     var version = req.param('version');
     var channel = req.param('channel') || 'stable';
     const flavor = req.params.flavor || 'default';
-
     if (!version) {
       return res.badRequest('Requires `version` parameter');
     }
@@ -417,14 +416,11 @@ module.exports = {
 
             sails.log.debug('Latest Windows Version', latestVersion);
 
-            // Change asset name to use full download link
-            const assets = _.map(latestVersion.assets, function (asset) {
-              asset.name = url.resolve(
-                sails.config.appUrl,
-                `/download/flavor/${flavor}/${latestVersion.name}/${asset.platform}/` +
-                asset.name
-              );
 
+            // Change asset name to use full download link 
+            /* Updated the full download link to use direct GCP URL */
+            const assets = _.map(latestVersion.assets, function (asset) {
+              asset.name = customFileAdapter.getSignedURL(latestVersion.assets[0].fd)
               return asset;
             });
 


### PR DESCRIPTION
Updated the code to send direct gcp signed url back to the frontend so that Windows updates download directly from GCP saving us money on egress